### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
 		"type": "git",
 		"url": "git+https://github.com/porada/prettier-plugin-yaml.git"
 	},
+	"bugs": {
+		"url": "https://github.com/porada/prettier-plugin-yaml/issues"
+	},
+	"homepage": "https://github.com/porada/prettier-plugin-yaml#readme",
 	"keywords": [
 		"formatting",
 		"prettier",


### PR DESCRIPTION
## Summary

- add `bugs` metadata for the repository issue tracker
- add the repository README as the package `homepage`

## Verification

- `node -e "const p=require('./package.json'); if (p.bugs?.url !== 'https://github.com/porada/prettier-plugin-yaml/issues' || p.homepage !== 'https://github.com/porada/prettier-plugin-yaml#readme') process.exit(1); console.log(JSON.stringify({name:p.name, version:p.version, bugs:p.bugs, homepage:p.homepage}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

This is an AI-assisted package metadata cleanup.
