### PR TITLE
Add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
 		"type": "git",
 		"url": "git+https://github.com/porada/prettier-plugin-yaml.git"
 	},
+	"bugs": {
+		"url": "https://github.com/porada/prettier-plugin-yaml/issues"
+	},
+	"homepage": "https://github.com/porada/prettier-plugin-yaml#readme",
 	"keywords": [
 		"formatting",
 		"prettier",


### PR DESCRIPTION
Summary:
- Add `bugs.url` pointing to the GitHub issue tracker.
- Add `homepage` pointing to the repository README.
- Leave runtime code, dependencies, scripts, and package version unchanged.

Why:
- The published npm metadata currently exposes repository information but not standard support/homepage links.
- This addresses the package metadata gap described in https://github.com/charles-openclaw/charles-microbounties/issues/1353.

Validation:
- `node -e "const p=require('./package.json'); if(p.name!=='prettier-plugin-yaml') throw new Error('name mismatch'); if(p.repository?.url!=='git+https://github.com/porada/prettier-plugin-yaml.git') throw new Error('repository mismatch'); if(p.bugs?.url!=='https://github.com/porada/prettier-plugin-yaml/issues') throw new Error('bugs mismatch'); if(p.homepage!=='https://github.com/porada/prettier-plugin-yaml#readme') throw new Error('homepage mismatch'); console.log('metadata ok');"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Bounty claim:
- Source bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1353
- This PR adds the requested `bugs` and `homepage` package metadata fields.
- Any payout/account setup remains owner-only.

Disclosure:
- Prepared with AI assistance and manually validated before submission.