### PR TITLE
Add package homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,13 @@
 		"email": "dom@dom.engineering",
 		"url": "https://dom.engineering"
 	},
+	"homepage": "https://github.com/porada/prettier-plugin-yaml#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/porada/prettier-plugin-yaml.git"
+	},
+	"bugs": {
+		"url": "https://github.com/porada/prettier-plugin-yaml/issues"
 	},
 	"keywords": [
 		"formatting",


### PR DESCRIPTION
Adds the missing `homepage` and `bugs` fields to `package.json` so npm displays the project homepage and issue tracker metadata.

Verification:
- `node -e "const p=require('./package.json'); if (p.homepage !== 'https://github.com/porada/prettier-plugin-yaml#readme') process.exit(1); if (p.bugs.url !== 'https://github.com/porada/prettier-plugin-yaml/issues') process.exit(1); console.log('package metadata verified')"`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`

Note: `pnpm lint:check` currently fails in this environment due to an oxc allocator panic (`crates/oxc_allocator/src/pool/fixed_size.rs`), not due to this package metadata change.